### PR TITLE
Add matches

### DIFF
--- a/lib/matchr/match_generator.ex
+++ b/lib/matchr/match_generator.ex
@@ -1,8 +1,56 @@
 defmodule Matchr.MatchGenerator do
 
+  def match_users(skills, available_users), do: match_users(skills, available_users, [])
+  def match_users([], available_users, matches), do: {matches, Enum.map(available_users, fn(u) -> u.id end)}
+  def match_users(_, [], matches), do: {matches, []}
+
+  def match_users(skills, available_users, matches) do
+    [skill | remaining_skills] = skills
+    {new_matches, remaining_users} = find_matches_for_skill(skill, available_users)
+    updated_matches = matches ++ new_matches
+    match_users(remaining_skills, remaining_users, updated_matches)
+  end
+
+  defp find_matches_for_skill(skill, available_users) do
+    case Enum.filter(skill.teachers, fn(teacher) -> user_is_available(teacher, available_users) end) do
+      [] -> {[], available_users}
+      available_teachers -> find_matches_for_available_teachers(skill, available_teachers, available_users)
+    end
+  end
+
+  defp find_matches_for_available_teachers(skill, teachers, available_users) do
+    Enum.reduce(teachers, {[], available_users}, fn(teacher, acc) -> find_match_for_available_teacher(skill, teacher, acc, available_users) end)
+  end
+
+  defp find_match_for_available_teacher(skill, teacher, acc, available_users) do
+    case Enum.filter(skill.learners, fn(student) -> user_is_available(student, available_users) end) do
+      [] -> acc
+      available_students -> create_match_if_possible(skill, teacher, available_students, acc, available_users)
+    end
+  end
+
+  defp create_match_if_possible(skill, teacher, available_students, acc, available_users) do
+    [student | remaining_students] = available_students
+    case student do
+      [] -> acc
+      _ -> if student != teacher, do: create_match(teacher, student, skill, acc, available_users), else: create_match_if_possible(skill, teacher, remaining_students, acc, available_users)
+    end
+  end
+
+  defp create_match(teacher, learner, skill, acc, available_users) do
+    {current_matches, users} = acc
+    remaining_users = Enum.filter(users, fn(user) -> (user.id != teacher.id && user.id != learner.id) end)
+    {current_matches ++ [%{teacher_id: teacher.id, learner_id: learner.id, skill_id: skill.id}], remaining_users}
+  end
+
   def sort_skills(skills) do
-    # Enum.sort_by(skills, &score/1)
     Enum.sort_by(skills, &score/1)
+  end
+
+  defp user_is_available(user, available_users) do
+    available_users
+    |> Enum.map(fn(user) -> user.id end)
+    |> Enum.member?(user.id)
   end
 
   defp score(skill) do

--- a/lib/matchr/match_generator.ex
+++ b/lib/matchr/match_generator.ex
@@ -1,0 +1,36 @@
+defmodule Matchr.MatchGenerator do
+
+  def sort_skills(skills) do
+    # Enum.sort_by(skills, &score/1)
+    Enum.sort_by(skills, &score/1)
+  end
+
+  defp score(skill) do
+    length(skill.teachers) - length(skill.learners)
+  end
+
+  def remove_skills_with_no_teachers_or_no_learners(skills) do
+    skills
+    |> reduce_skills_for_func(&no_teacher/2)
+    |> reduce_skills_for_func(&no_learner/2)
+  end
+
+  defp reduce_skills_for_func(skills, func) do
+    skills
+    |> Enum.reduce([], func)
+  end
+
+  defp no_teacher(skill, acc) do
+    case skill.teachers do
+      [] -> acc
+      _ -> acc ++ [skill]
+    end
+  end
+
+  defp no_learner(skill, acc) do
+   case skill.learners do
+      [] -> acc
+      _ -> acc ++ [skill]
+    end
+  end
+end

--- a/priv/repo/migrations/20170210210429_create_match_table.exs
+++ b/priv/repo/migrations/20170210210429_create_match_table.exs
@@ -1,0 +1,13 @@
+defmodule Matchr.Repo.Migrations.CreateMatchTable do
+  use Ecto.Migration
+
+  def change do
+    create table(:matches) do
+      add :teacher_id, :integer, null: false
+      add :learner_id, :integer, null: false
+      add :skill_id, :integer, null: false
+
+      timestamps()
+    end
+  end
+end

--- a/test/matchr/match_generator_test.exs
+++ b/test/matchr/match_generator_test.exs
@@ -1,0 +1,62 @@
+defmodule Matchr.MatchGeneratorTest do
+  use Matchr.ModelCase
+  alias Matchr.Skills
+  alias Matchr.Users
+  alias Matchr.MatchGenerator
+
+  def insert_skill(skill_attributes \\ %{}) do
+    %{
+      name: "skill name",
+    }
+    |> Map.merge(skill_attributes)
+    |> Skills.insert
+  end
+
+  def insert_user() do
+    Users.insert(%{name: "Dave"})
+  end
+
+  test "removes skills with no teacher" do
+    {:ok, user1} = insert_user
+    {:ok, user2} = insert_user
+    insert_skill
+    insert_skill(%{name: "two", learners: [user1], teachers: [user2]})
+
+    skills = Skills.load_all
+    |> MatchGenerator.remove_skills_with_no_teachers_or_no_learners
+
+    assert length(skills) == 1
+  end
+
+  test "removes skills with no learner" do
+    {:ok, user1} = insert_user
+    {:ok, user2} = insert_user
+    insert_skill
+    insert_skill(%{name: "two", learners: [user1], teachers: [user2]})
+
+    skills = Skills.load_all
+    |> MatchGenerator.remove_skills_with_no_teachers_or_no_learners
+
+    assert length(skills) == 1
+  end
+
+  test "sorts skills based on difference between learners and teachers" do
+    {:ok, user1} = insert_user
+    {:ok, user2} = insert_user
+    {:ok, user3} = insert_user
+    {:ok, user4} = insert_user
+    {:ok, skill1} = insert_skill(%{name: "one", learners: [user1, user2, user3, user4], teachers: [user2, user3, user4]})
+    {:ok, skill2} = insert_skill(%{name: "one", learners: [user4], teachers: [user2]})
+    {:ok, skill3} = insert_skill(%{name: "one", learners: [user3, user4, user2], teachers: [user2]})
+    {:ok, skill4} = insert_skill(%{name: "one", learners: [user1, user2, user3, user4], teachers: [user2]})
+
+    skills = Skills.load_all
+      |> MatchGenerator.sort_skills
+
+    assert Enum.map(skills, &skill_id/1) == [skill4.id, skill3.id, skill1.id, skill2.id]
+  end
+
+  def skill_id(skill) do
+    skill.id
+  end
+end

--- a/test/matchr/match_generator_test.exs
+++ b/test/matchr/match_generator_test.exs
@@ -12,13 +12,17 @@ defmodule Matchr.MatchGeneratorTest do
     |> Skills.insert
   end
 
-  def insert_user() do
-    Users.insert(%{name: "Dave"})
+  def insert_user(name) do
+    Users.insert(%{name: name})
+  end
+
+  def skill_id(skill) do
+    skill.id
   end
 
   test "removes skills with no teacher" do
-    {:ok, user1} = insert_user
-    {:ok, user2} = insert_user
+    {:ok, user1} = insert_user("Ben")
+    {:ok, user2} = insert_user("Sally")
     insert_skill
     insert_skill(%{name: "two", learners: [user1], teachers: [user2]})
 
@@ -29,8 +33,8 @@ defmodule Matchr.MatchGeneratorTest do
   end
 
   test "removes skills with no learner" do
-    {:ok, user1} = insert_user
-    {:ok, user2} = insert_user
+    {:ok, user1} = insert_user("Ben")
+    {:ok, user2} = insert_user("Sally")
     insert_skill
     insert_skill(%{name: "two", learners: [user1], teachers: [user2]})
 
@@ -41,10 +45,10 @@ defmodule Matchr.MatchGeneratorTest do
   end
 
   test "sorts skills based on difference between learners and teachers" do
-    {:ok, user1} = insert_user
-    {:ok, user2} = insert_user
-    {:ok, user3} = insert_user
-    {:ok, user4} = insert_user
+    {:ok, user1} = insert_user("Ben")
+    {:ok, user2} = insert_user("Sally")
+    {:ok, user3} = insert_user("Torrence")
+    {:ok, user4} = insert_user("Bean")
     {:ok, skill1} = insert_skill(%{name: "one", learners: [user1, user2, user3, user4], teachers: [user2, user3, user4]})
     {:ok, skill2} = insert_skill(%{name: "one", learners: [user4], teachers: [user2]})
     {:ok, skill3} = insert_skill(%{name: "one", learners: [user3, user4, user2], teachers: [user2]})
@@ -56,7 +60,41 @@ defmodule Matchr.MatchGeneratorTest do
     assert Enum.map(skills, &skill_id/1) == [skill4.id, skill3.id, skill1.id, skill2.id]
   end
 
-  def skill_id(skill) do
-    skill.id
+  test "simple match with no remaining" do
+    {:ok, user1} = insert_user("Ben")
+    {:ok, user2} = insert_user("Sally")
+    {:ok, skill} = insert_skill(%{name: "RUBY", learners: [user1], teachers: [user2]})
+    available_users = Users.load_all
+
+    {matches, remaining_users} = Skills.load_all
+      |> MatchGenerator.sort_skills
+      |> MatchGenerator.match_users(available_users)
+
+    assert matches == [
+      %{learner_id: user1.id, teacher_id: user2.id, skill_id: skill.id},
+    ]
+    assert remaining_users == []
+  end
+
+  test "match two skills with a remaining" do
+    {:ok, user1} = insert_user("Ben")
+    {:ok, user2} = insert_user("Sally")
+    {:ok, user3} = insert_user("Torrence")
+    {:ok, user4} = insert_user("Bean")
+    {:ok, user5} = insert_user("Elektra")
+    {:ok, skill} = insert_skill(%{name: "RUBY", learners: [user1], teachers: [user3, user4]})
+    {:ok, skill2} = insert_skill(%{name: "SKETCH", learners: [user4], teachers: [user2]})
+    available_users = Users.load_all
+
+    {matches, remaining_users} = Skills.load_all
+      |> MatchGenerator.remove_skills_with_no_teachers_or_no_learners
+      |> MatchGenerator.sort_skills
+      |> MatchGenerator.match_users(available_users)
+
+    assert matches == [
+      %{learner_id: user4.id, teacher_id: user2.id, skill_id: skill2.id},
+      %{learner_id: user1.id, teacher_id: user3.id, skill_id: skill.id},
+    ]
+    assert remaining_users == [user5.id]
   end
 end

--- a/test/models/match_test.exs
+++ b/test/models/match_test.exs
@@ -1,0 +1,31 @@
+defmodule Matchr.MatchTest do
+  use Matchr.ModelCase
+
+  alias Matchr.Match
+
+  @valid_attrs %{
+    teacher_id: 0,
+    learner_id: 0,
+    skill_id: 0,
+  }
+
+  test "changeset is valid with valid attributes" do
+    changeset = Match.changeset(%Match{}, @valid_attrs)
+    assert changeset.valid?
+  end
+
+  test "changeset requires teacher_id" do
+    changeset = Match.changeset(%Match{}, %{@valid_attrs | teacher_id: nil})
+    refute changeset.valid?
+  end
+
+  test "changeset requires learner_id" do
+    changeset = Match.changeset(%Match{}, %{@valid_attrs | learner_id: nil})
+    refute changeset.valid?
+  end
+
+  test "changeset requires skill_id" do
+    changeset = Match.changeset(%Match{}, %{@valid_attrs | skill_id: nil})
+    refute changeset.valid?
+  end
+end

--- a/test/repos/matches_test.exs
+++ b/test/repos/matches_test.exs
@@ -1,0 +1,53 @@
+defmodule Matchr.MatchesTest do
+  use Matchr.ModelCase
+  alias Matchr.Matches
+
+  @valid_match_attrs %{
+    teacher_id: 9,
+    learner_id: 0,
+    skill_id: 1,
+  }
+
+  describe "insert" do
+    test "inserts a match" do
+      {code, inserted_match} = Matches.insert(@valid_match_attrs)
+
+      assert code == :ok
+      assert inserted_match.teacher_id == 9
+      assert inserted_match.learner_id == 0
+      assert inserted_match.skill_id == 1
+      assert Matches.count == 1
+    end
+
+    test "returns error for invalid attributes" do
+      {code, _} = Matches.insert(%{})
+
+      assert code == :error
+    end
+  end
+
+  describe "load" do
+    test "returns a match record based on an id" do
+      {:ok, inserted_match} = Matches.insert(@valid_match_attrs)
+
+      match = Matches.load(inserted_match.id)
+
+      assert match.id == inserted_match.id
+    end
+
+    test "returns nill for invalid id" do
+      assert Matches.load(999) == nil
+    end
+  end
+
+  describe "load_all" do
+    test "returns all matches" do
+      Matches.insert(@valid_match_attrs)
+      Matches.insert(@valid_match_attrs)
+
+      matches = Matches.load_all
+
+      assert length(matches) == 2
+    end
+  end
+end

--- a/test/views/skill_view_test.exs
+++ b/test/views/skill_view_test.exs
@@ -37,7 +37,7 @@ defmodule Matchr.SkillViewTest do
     test "renders a skill with users" do
       {:ok, user1} = insert_user()
       {:ok, user2} = insert_user(%{name: "other"})
-      {:ok, skill} = insert_skill(%{users_that_can_teach: [user1], users_that_want_to_learn: [user2]})
+      {:ok, skill} = insert_skill(%{teachers: [user1], learners: [user2]})
 
       rendered_skill = SkillView.render("show.json", skill: Skills.load(skill.id))
 

--- a/web/models/match.ex
+++ b/web/models/match.ex
@@ -1,0 +1,24 @@
+defmodule Matchr.Match do
+  use Matchr.Web, :model
+
+  schema "matches" do
+    field :teacher_id, :integer
+    field :learner_id, :integer
+    field :skill_id, :integer
+    timestamps()
+  end
+
+  @required_attributes [
+   :teacher_id,
+   :learner_id,
+   :skill_id
+  ]
+
+  @optional_attributes []
+
+  def changeset(struct, params \\ %{}) do
+    struct
+    |> cast(params, @required_attributes ++ @optional_attributes)
+    |> validate_required(@required_attributes)
+  end
+end

--- a/web/models/skill.ex
+++ b/web/models/skill.ex
@@ -3,13 +3,13 @@ defmodule Matchr.Skill do
 
   schema "skills" do
     field :name, :string
-    many_to_many :users_that_want_to_learn, Matchr.User, join_through: "user_wants_to_learn_skill", on_replace: :delete
-    many_to_many :users_that_can_teach, Matchr.User, join_through: "user_can_teach_skill", on_replace: :delete
+    many_to_many :learners, Matchr.User, join_through: "user_wants_to_learn_skill", on_replace: :delete
+    many_to_many :teachers, Matchr.User, join_through: "user_can_teach_skill", on_replace: :delete
     timestamps()
   end
 
   @required_attributes [
-    :name,
+    :name
   ]
 
   @optional_attributes []

--- a/web/repos/matches.ex
+++ b/web/repos/matches.ex
@@ -1,0 +1,22 @@
+defmodule Matchr.Matches do
+  use Matchr.Repo
+  alias Matchr.Match
+
+  def insert(match_attributes) do
+    Match.changeset(%Match{}, match_attributes)
+    |> Repo.insert
+  end
+
+  def count do
+    Repo.aggregate(Match, :count, :id)
+  end
+
+  def load(id) do
+    Repo.get(Match, id)
+  end
+
+  def load_all do
+    from(m in Match)
+    |> Repo.all
+  end
+end

--- a/web/repos/skills.ex
+++ b/web/repos/skills.ex
@@ -20,21 +20,21 @@ defmodule Matchr.Skills do
 
   defp assoc_users(changeset, skill_attributes) do
    changeset
-    |> assoc_users_that_want_to_learn(skill_attributes)
-    |> assoc_users_that_can_teach(skill_attributes)
+    |> assoc_learners(skill_attributes)
+    |> assoc_teachers(skill_attributes)
   end
 
-  defp assoc_users_that_want_to_learn(changeset, skill_attributes) do
-    case skill_attributes[:users_that_want_to_learn] do
+  defp assoc_learners(changeset, skill_attributes) do
+    case skill_attributes[:learners] do
       nil -> changeset
-      _ -> Ecto.Changeset.put_assoc(changeset, :users_that_want_to_learn, skill_attributes[:users_that_want_to_learn])
+      _ -> Ecto.Changeset.put_assoc(changeset, :learners, skill_attributes[:learners])
     end
   end
 
-  defp assoc_users_that_can_teach(changeset, skill_attributes) do
-    case skill_attributes[:users_that_can_teach] do
+  defp assoc_teachers(changeset, skill_attributes) do
+    case skill_attributes[:teachers] do
       nil -> changeset
-      _ -> Ecto.Changeset.put_assoc(changeset, :users_that_can_teach, skill_attributes[:users_that_can_teach])
+      _ -> Ecto.Changeset.put_assoc(changeset, :teachers, skill_attributes[:teachers])
     end
   end
 
@@ -42,8 +42,8 @@ defmodule Matchr.Skills do
     case Repo.get(Skill, id) do
       nil -> nil
       skill -> skill
-      |> Repo.preload(:users_that_want_to_learn)
-      |> Repo.preload(:users_that_can_teach)
+      |> Repo.preload(:learners)
+      |> Repo.preload(:teachers)
     end
   end
 
@@ -53,15 +53,15 @@ defmodule Matchr.Skills do
 
   def load_all() do
     list
-    |> preload(:users_that_want_to_learn)
-    |> preload(:users_that_can_teach)
+    |> preload(:learners)
+    |> preload(:teachers)
     |> Repo.all
   end
 
   def load_all(query) do
     query
-    |> preload(:users_that_want_to_learn)
-    |> preload(:users_that_can_teach)
+    |> preload(:learners)
+    |> preload(:teachers)
     |> Repo.all
   end
 

--- a/web/views/skill_view.ex
+++ b/web/views/skill_view.ex
@@ -34,20 +34,20 @@ defmodule Matchr.SkillView do
       "id" => skill.id,
       "name" => skill.name,
     }
-    |> put_users_that_can_teach(skill)
-    |> put_users_that_want_to_learn(skill)
+    |> put_teachers(skill)
+    |> put_learners(skill)
   end
 
-  defp put_users_that_can_teach(json, skill) do
-    case skill.users_that_can_teach do
+  defp put_teachers(json, skill) do
+    case skill.teachers do
       %Ecto.Association.NotLoaded{} -> json
       [] -> json
       users -> Map.put(json, "usersThatCanTeach", render_many(users, Matchr.UserView, "user.json"))
     end
   end
 
-  defp put_users_that_want_to_learn(json, skill) do
-    case skill.users_that_want_to_learn do
+  defp put_learners(json, skill) do
+    case skill.learners do
       %Ecto.Association.NotLoaded{} -> json
       [] -> json
       users -> Map.put(json, "usersThatWantToLearn", render_many(users, Matchr.UserView, "user.json"))


### PR DESCRIPTION
This PR adds the concept of `Matches`.

This commit pretty much sayings everything:

  1) Added a matches table
  2) Added a model and a repo for matches
  3) Added MatchGenerator
    - It eliminates skills with no teachers or students
    - It sorts the remaining skills by the learner to teacher ratio